### PR TITLE
Fixes build_static error "ld: cannot find -lm -lcrypto".

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ class AmalgationLibSqliteBuilder(build_ext):
 
         if sys.platform != "win32":
             # Include math library, required for fts5, and crypto.
-            ext.extra_link_args.append("-lm -lcrypto")
+            ext.extra_link_args.extend(["-lm", "-lcrypto"])
         else:
             # Try to locate openssl.
             openssl_conf = os.environ.get('OPENSSL_CONF')


### PR DESCRIPTION
I find the documentation a bit vague, at the very least, on extra_link_args, so I'm not sure, whether the previous version should ever worked, but failed for me on alpine 3.10, ubuntu 19.04 and macOS 10.13.