### PR TITLE
Fixes missing sqlcipher/sqlite3.h header for build_static.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,8 @@ class AmalgationLibSqliteBuilder(build_ext):
         # it is responsibility of user to provide amalgamation
         self.check_amalgamation()
 
+        ext.define_macros.append(("PYSQLITE_AMALGATION_BUILD", None))
+
         # Feature-ful library.
         features = (
             'ENABLE_FTS3',

--- a/src/connection.h
+++ b/src/connection.h
@@ -31,7 +31,11 @@
 #include "cache.h"
 #include "module.h"
 
-#include "sqlcipher/sqlite3.h"
+#ifdef PYSQLITE_AMALGATION_BUILD
+    #include "sqlite3.h"
+#else
+    #include "sqlcipher/sqlite3.h"
+#endif
 
 typedef struct
 {

--- a/src/statement.h
+++ b/src/statement.h
@@ -27,7 +27,11 @@
 #include "Python.h"
 
 #include "connection.h"
-#include "sqlcipher/sqlite3.h"
+#ifdef PYSQLITE_AMALGATION_BUILD
+    #include "sqlite3.h"
+#else
+    #include "sqlcipher/sqlite3.h"
+#endif
 
 #define PYSQLITE_TOO_MUCH_SQL (-100)
 #define PYSQLITE_SQL_WRONG_TYPE (-101)

--- a/src/util.h
+++ b/src/util.h
@@ -26,7 +26,11 @@
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
 #include "pythread.h"
-#include "sqlcipher/sqlite3.h"
+#ifdef PYSQLITE_AMALGATION_BUILD
+    #include "sqlite3.h"
+#else
+    #include "sqlcipher/sqlite3.h"
+#endif
 #include "connection.h"
 
 int pysqlite_step(sqlite3_stmt* statement, pysqlite_Connection* connection);


### PR DESCRIPTION
This is an attempt to fix the same problem described in rigglemania/pysqlcipher3#15.
While the approach in rigglemania/pysqlcipher3@6ca3743 is reasonable for dynamic linking, it broke the amalgation build.
There must be a better way to do this, but I couldn't came up with a better idea at the moment, and it works...