### PR TITLE
fix(build): enable Windows static build with OpenSSL 3.x support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,49 @@
-sqlcipher/sqlite3.h
-build/*
-dist/*
-sqlcipher3.egg-info/*
-_sqlite*.so
+# Build artifacts
+build/
+dist/
+*.egg-info/
+*.egg
+
+# Compiled files
+*.pyc
+__pycache__/
+*.so
+*.pyd
+*.obj
+*.lib
+*.exp
+*.pdb
+
+# Test artifacts
+*.db
+*.db-journal
+test_*.db
+
+# Logs
+*.log
+build_output.txt
+diag_output.txt
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Temporary files
+*.tmp
+temp/
+
+# Local test scripts
+test_*.py
+final_integration_test.py
+run_all_tests.sh
+run_openssl3_tests.py
+
+# Local directories
+sqlcipher/
+amalgamation/


### PR DESCRIPTION
This PR enables reliable static builds on Windows with OpenSSL 3.x and MSVC.

### Changes
- Add required Windows system libraries (`ws2_32`, `advapi32`, `user32`, `gdi32`, `crypt32`)
- Use `libcrypto`/`libssl` names for OpenSSL 3.x
- Add `/std:c11` flag and SQLCipher macros
- Remove `SQLITE_AMALGAMATION` macro to fix object file size issue
- Hardcoded source path to `amalgamation/sqlite3.c` for reliable static builds

### Usage Note
Users can build statically by placing SQLCipher amalgamation files in an `amalgamation/` folder and running:
`python setup.py build_static build_ext --inplace`

### Tested on
- Windows 11 x64 / Python 3.14 (No-GIL) / MSVC v143 / OpenSSL 3.x
- Static build successful (.pyd ~1.8MB)
- Full encryption tests passed (Basic, Unicode, Memory, Error Handling)